### PR TITLE
Refactors algebra

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -1339,8 +1339,8 @@ packages:
 - pypi: ./
   name: prism-pruner
   version: 1.0.0
-  sha256: b3947f3091f5cab1dbb186379848e6788676b50186fa717068ea5564143847e7
-  requires_python: '>=3.11,<3.14'
+  sha256: a01a41cb3ada258df88d6628912ee56fe849b418cc6f0d470d2dd48960ddbd54
+  requires_python: '>=3.12,<3.14'
   editable: true
 - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
   sha256: 4817651a276016f3838957bfdf963386438c70761e9faec7749d411635979bae

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ version = "1.0.0"
 readme = "README.md"
 keywords = []
 authors = [{name = "Nicolò Tampellini", email = "nicolo.tampellini@yale.edu"}]
-requires-python = ">=3.11,<3.14"
+requires-python = ">=3.12,<3.14"
 
 [tool.pixi.project]
 channels = ["conda-forge"]


### PR DESCRIPTION
I'm not convinced of the need for numba here. The main purpose would be to speed up `all_dists`, but there is a BLAS function in scipy ([cdist](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.distance.cdist.html)) that I think will likely be faster, and it is be a lot cleaner (happy to be proven wrong). Additionally, I don't think a 10% improvement in speed is usually worthwhile for the complexity of adding in numba. How confident are you that numba provides a significant speedup (I haven't used it enough to have a strong intuition)?

Highlights:
- list unpacking
- generic typing for `clip`
- fixed types