### PR TITLE
17 tiny molecules cause issues

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -5,6 +5,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -193,6 +195,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -4218,15 +4222,14 @@ packages:
   timestamp: 1762692428418
 - pypi: ./
   name: prism-pruner
-  version: 0.0.7
-  sha256: 6db492c571d3efb97ffc8966a1a24e6817ce4c5fffc3ecdf07e78511eed93184
+  version: 0.0.9
+  sha256: 861b1299392412364837eb1711fe4531c0f041365bd95d3b77149a8bda2327a8
   requires_dist:
   - networkx>=3.0
   - numpy>=2.0
   - scipy>=1.10
   - tqdm>=4
   requires_python: '>=3.12'
-  editable: true
 - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.23.1-pyhd8ed1ab_0.conda
   sha256: 13dc67de68db151ff909f2c1d2486fa7e2d51355b25cee08d26ede1b62d48d40
   md5: a1e91db2d17fd258c64921cb38e6745a

--- a/prism_pruner/pruner.py
+++ b/prism_pruner/pruner.py
@@ -187,6 +187,15 @@ class MOIPrunerConfig(PrunerConfig):
             for c, coord in enumerate(self.structures)
         }
 
+        # check the first structure to assess if any
+        # moment is zero and we should therefore not
+        # bother using it to compare structures
+        self.check_I_on_axis: tuple[bool, bool, bool] = (
+            self.moi_vecs[0][0] > 1e-6,
+            self.moi_vecs[0][1] > 1e-6,
+            self.moi_vecs[0][2] > 1e-6,
+        )
+
     def evaluate_sim(self, i1: int, i2: int) -> bool:
         """Return whether the structures are similar."""
         im_1 = self.moi_vecs[i1]
@@ -195,8 +204,8 @@ class MOIPrunerConfig(PrunerConfig):
         # compare the three MOIs via a Python loop:
         # apparently much faster than numpy array operations
         # for such a small array!
-        for j in range(3):
-            if np.abs(im_1[j] - im_2[j]) / im_1[j] >= self.max_dev:
+        for j, check_axis in enumerate(self.check_I_on_axis):
+            if check_axis and np.abs(im_1[j] - im_2[j]) / im_1[j] >= self.max_dev:
                 return False
         return True
 
@@ -503,8 +512,9 @@ def _batch_rmsd_prune(
     start_t = perf_counter()
 
     N = len(structures)
+    M = int(np.count_nonzero(atoms != "H"))
     heavy_mask: Array1D_bool = (
-        atoms != "H" if heavy_atoms_only else np.ones(structures.shape[1], dtype=bool)
+        atoms != "H" if (heavy_atoms_only and M > 0) else np.ones(structures.shape[1], dtype=bool)
     )
     M = int(heavy_mask.sum())
 

--- a/prism_pruner/pruner.py
+++ b/prism_pruner/pruner.py
@@ -512,7 +512,10 @@ def _batch_rmsd_prune(
     start_t = perf_counter()
 
     N = len(structures)
+
+    # check how many heavy atoms: if none, use all
     M = int(np.count_nonzero(atoms != "H"))
+
     heavy_mask: Array1D_bool = (
         atoms != "H" if (heavy_atoms_only and M > 0) else np.ones(structures.shape[1], dtype=bool)
     )

--- a/prism_pruner/pruner.py
+++ b/prism_pruner/pruner.py
@@ -143,7 +143,7 @@ class RMSDPrunerConfig(PrunerConfig):
         assert type(self.atoms) is np.ndarray
 
         # pre-compute heavy atom mask once
-        if self.heavy_atoms_only:
+        if self.heavy_atoms_only and np.count_nonzero(self.atoms != "H") > 0:
             self._heavy_mask: Array1D_bool = self.atoms != "H"
         else:
             self._heavy_mask = np.ones(self.atoms.shape[0], dtype=np.bool_)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "prism_pruner"
 description = "Prism Pruner"
 license = "MIT"
-version = "0.0.7"
+version = "0.0.9"
 readme = "README.md"
 keywords = []
 authors = [{name = "Nicolò Tampellini", email = "nicolo.tampellini@yale.edu"}]


### PR DESCRIPTION
- Added checks for linear molecules, single atoms, and non-heavy molecules (i.e. only made up of "H" atoms, for now).
- Avoids RuntimeWarnings and appears to have the desired behavior.
- Does not seem too detrimental to the performance of large ensembles.

@corinwagen Do you want to give this a try and see if performance is not impacted on your end as well?